### PR TITLE
Set a default sqlitePath

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,6 +4,7 @@
 export function setDefaultConfig(initialConfig) {
   const defaults = {
     skipImport: false,
+    sqlitePath: '/tmp/gtfs',
   };
 
   return Object.assign(defaults, initialConfig);


### PR DESCRIPTION
Set the config param `sqlitePath` in the default config.  Without this, an error will be thrown by `db.js:10 setupDb` when run without a config specified by `--configPath` while when attempting to export GTFS before exiting the program.

Current Behavior:

Program exits with error:
```
Error: TypeError: Expected a string, got undefined
[  TypeError: Expected a string, got undefined

  - index.js:7 untildify
    [gtfs-tts]/[untildify]/index.js:7:9

  - db.js:10 setupDb
    [gtfs-tts]/[gtfs]/lib/db.js:10:27

  - db.js:31 openDb
    [gtfs-tts]/[gtfs]/lib/db.js:31:12

  - export.js:37 exportGtfs
    [gtfs-tts]/[gtfs]/lib/export.js:37:14

  - gtfs-tts.js:215 gtfsTTS
    file:///.../gtfs-tts/dist/bin/gtfs-tts.js:215:9

  - gtfs-tts.js:254 async setupImport
    file:///.../gtfs-tts/dist/bin/gtfs-tts.js:254:3

]
```

New Behavior:
Program exits with success:
```
Starting GTFS export for 1 agency using SQLite database at /tmp/gtfs
Exporting - agency.txt
...
```